### PR TITLE
Fix build with rust 1 84

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,18 +5811,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc4f90c27b57691bbaf11d8ecc7cfbfe98a4da6dbe60226115d322aa80c06e"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sev 6.3.1",
+ "sev 6.3.0",
  "sha2 0.10.9",
  "strum",
  "tdx-attest-rs",
@@ -495,14 +495,14 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b3d0900c6757c9674b05b0479236458297026e25fb505186dc8d7735091a21c"
 dependencies = [
- "bincode 1.3.3",
+ "bincode",
  "jsonwebkey",
  "memoffset 0.9.1",
  "openssl",
  "serde",
  "serde-big-array",
  "serde_json",
- "sev 6.3.1",
+ "sev 6.3.0",
  "sha2 0.10.9",
  "thiserror 2.0.16",
  "tss-esapi",
@@ -516,10 +516,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e5f1a3838d56871fc7a37c1ffcaa892777fbebb246f7ddec18c12e14b6d6aa9"
 dependencies = [
  "az-cvm-vtpm",
- "bincode 1.3.3",
+ "bincode",
  "clap",
  "serde",
- "sev 6.3.1",
+ "sev 6.3.0",
  "thiserror 2.0.16",
  "ureq",
 ]
@@ -532,7 +532,7 @@ checksum = "04849677b3c0704d4593d89940cde0dc0caad2202bf9fb29352e153782b91ff8"
 dependencies = [
  "az-cvm-vtpm",
  "base64-url",
- "bincode 1.3.3",
+ "bincode",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -611,26 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -1538,7 +1518,7 @@ name = "csv-rs"
 version = "0.1.0"
 source = "git+https://github.com/openanolis/csv-rs.git?rev=9e92ac7#9e92ac7e73379c1206ce90c98e91b1b5391eb7f8"
 dependencies = [
- "bincode 1.3.3",
+ "bincode",
  "bitfield 0.13.2",
  "bitflags 1.3.2",
  "codicon",
@@ -3402,7 +3382,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bincode 1.3.3",
+ "bincode",
  "crypto",
  "kbs_protocol",
  "log",
@@ -3485,7 +3465,7 @@ dependencies = [
  "async-trait",
  "attestation-agent",
  "base64 0.22.1",
- "bincode 1.3.3",
+ "bincode",
  "chrono",
  "const_format",
  "crypto",
@@ -6184,12 +6164,12 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.3.1"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420c6c161b5d6883d8195584a802b114af6c884ed56d937d994e30f7f81d54ec"
+checksum = "d295a3e215c5c2a7d16bebd55c29e6e379599287846c5f9c6e7ef7e334383ced"
 dependencies = [
  "base64 0.22.1",
- "bincode 2.0.1",
+ "bincode",
  "bitfield 0.19.1",
  "bitflags 2.9.0",
  "byteorder",
@@ -7267,12 +7247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "ureq"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7363,12 +7337,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vm-memory"

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -33,7 +33,7 @@ scroll = { version = "0.13.0", default-features = false, features = [
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
-sev = { version = "6.3.1", default-features = false, features = [
+sev = { version = "=6.3.0", default-features = false, features = [
     "snp",
 ], optional = true }
 sha2.workspace = true

--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -26,7 +26,7 @@ log.workspace = true
 nvml-wrapper = { git = "https://github.com/rust-nvml/nvml-wrapper", rev="7e0752f331" , optional = true, default-features = false, features = ["serde"]}
 occlum_dcap = { git = "https://github.com/occlum/occlum", tag = "v0.29.7", optional = true }
 pv = { version = "0.10.0", package = "s390_pv", optional = true }
-scroll = { version = "0.13.0", default-features = false, features = [
+scroll = { version = "=0.12.0", default-features = false, features = [
     "derive",
     "std",
 ], optional = true }

--- a/protos/Cargo.toml
+++ b/protos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protos"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true, optional = true }


### PR DESCRIPTION
This is a tentative to fix the build of podvm-payload with rust < 1.85 in the CAA repo.