### PR TITLE
Revert "attestation-agent: Don't rebuild openssl from sources"

### DIFF
--- a/attestation-agent/deps/crypto/Cargo.toml
+++ b/attestation-agent/deps/crypto/Cargo.toml
@@ -14,7 +14,7 @@ base64.workspace = true
 concat-kdf = { version = "0.1.0", optional = true }
 ctr = { workspace = true, optional = true }
 kbs-types.workspace = true
-openssl = { workspace = true, optional = true }
+openssl = { workspace = true, features = ["vendored"], optional = true }
 p256 = { version = "0.13.1", features = ["ecdh", "pem"], optional = true }
 rand.workspace = true
 

--- a/ocicrypt-rs/Cargo.toml
+++ b/ocicrypt-rs/Cargo.toml
@@ -20,7 +20,7 @@ ctr = { workspace = true, optional = true }
 hmac = { workspace = true, optional = true }
 josekit = { version = ">=0.7", optional = true }
 kbc = { path = "../attestation-agent/kbc", default-features = false, optional = true }
-openssl = { workspace = true, optional = true }
+openssl = { workspace = true, features = ["vendored"], optional = true }
 pin-project-lite = { version = "0.2.16", optional = true }
 protos = { path = "../protos", default-features = false, optional = true }
 resource_uri = { path = "../attestation-agent/deps/resource_uri", optional = true }
@@ -38,7 +38,7 @@ zeroize = { workspace = true, optional = true }
 [dev-dependencies]
 aes-gcm.workspace = true
 ctrlc = { version = "3.5", features = ["termination"] }
-openssl = { workspace = true }
+openssl = { workspace = true, features = ["vendored"] }
 tokio = { workspace = true, features = ["time", "signal"] }
 
 [features]


### PR DESCRIPTION
This reverts commit 3f7dacf4d565d7c0f967444430c1faf274d4bb69.

This is a leftover from a previous tentative to stop vendoring openssl. It didn't succeed and we've switched to a bigger hammer (OPENSSL_NO_VENDOR).