### PR TITLE
Update csv-rs to use registry version

### DIFF
--- a/attestation-agent/attester/Cargo.toml
+++ b/attestation-agent/attester/Cargo.toml
@@ -40,8 +40,7 @@ sha2.workspace = true
 strum.workspace = true
 tdx-attest-rs = { git = "https://github.com/intel/confidential-computing.tee.dcap", tag = "DCAP_1.26", optional = true }
 thiserror.workspace = true
-# TODO: change it to "0.1", once released.
-csv-rs = { git = "https://github.com/openanolis/csv-rs.git", rev = "2243c67", optional = true }
+csv-rs = { version = "0.1.0", optional = true }
 codicon = { version = "3.0", optional = true }
 hyper = { version = "0.14", features = ["full"], optional = true }
 hyper-tls = { version = "0.5", optional = true }


### PR DESCRIPTION
Using git dependencies for csv-rs causes vendor collision in hermetic builds with hermeto/cachi2. When multiple workspaces reference the same crate from different git sources, hermeto vendors the crate multiple times, causing .cargo-checksum.json conflicts that break the build.

The csv-rs v0.1.0 is now available on crates.io. Switching to the registry version eliminates the git source and resolves the vendor collision.

Cherry-picked from upstream confidential-containers/guest-components commit 1fcebcb.